### PR TITLE
Test case to ensure setup/teardown are skipped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bin
 obj
+Launchable.NUnit.Test/TestResults
+.vscode

--- a/Launchable.NUnit.Test/SetupTeardown.cs
+++ b/Launchable.NUnit.Test/SetupTeardown.cs
@@ -1,0 +1,36 @@
+namespace Launchable.NUnit.Test;
+
+/// <summary>
+/// If all tests are skipped, does setup/teardown still happen?
+/// </summary>
+[TestFixture]
+public class SetupAndTeardownTest
+{
+    public SetupAndTeardownTest()
+    {
+        // even when tests are skipped, apparently instances are still constructed.
+        // if the following line is commented out, the test will fail
+        // throw new AssertionException("object shouldn't be constructed");
+    }
+
+    [SetUp]
+    public void Before()
+    {
+        Console.WriteLine("before");
+        throw new AssertionException("setup should have been skipped");
+    }
+
+    [TearDown]
+    public void After()
+    {
+        Console.WriteLine("after");
+        throw new AssertionException("teardown should have been skipped");
+    }
+
+    [Test]
+    public void Foo()
+    {
+        Console.WriteLine("foo");
+        throw new AssertionException("this test should have been skipped");
+    }
+}

--- a/Launchable.NUnit/Decorator.cs
+++ b/Launchable.NUnit/Decorator.cs
@@ -100,7 +100,8 @@ namespace Launchable.NUnit {
                 t.RunState = RunState.Skipped;
             }
             if (n=="Launchable.NUnit.Test.OneLineIntegrationTest.Test2"
-            ||  n=="Launchable.NUnit.Test.ParameterizedTests.DivideTest(2)")
+            ||  n=="Launchable.NUnit.Test.ParameterizedTests.DivideTest(2)"
+            ||  n=="Launchable.NUnit.Test.SetupAndTeardownTest.Foo")
             {// unit test probe
                 t.RunState = RunState.Skipped;
             }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ See https://www.launchableinc.com/docs/features/predictive-test-selection/reques
 
 ## Development instruction
 * `dotnet build` to build
-* `dotnet test` to run unit tests
+* `dotnet test` to run unit tests. `dotnet test -l:nunit` to produce TestResults.xml
 
 ## Release instruction
 * Update the version number in `Launchable.NUnit/*.csproj`


### PR DESCRIPTION
During a customer investigation I created this test case to verify the expected behaviour, that is, if tests are skipped, setup & teardown shouldn't run.